### PR TITLE
feat(cli): コマンド引数の構造を簡素化し、バージョンを更新

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt update -y && \
     apt install -y curl git sudo zstd && \
 
-    curl -L https://github.com/openai/codex/releases/download/rust-v0.34.0/codex-x86_64-unknown-linux-musl.zst -o codex.zst && \
+    curl -L https://github.com/openai/codex/releases/download/rust-v0.36.0/codex-x86_64-unknown-linux-musl.zst -o codex.zst && \
     zstd -d codex.zst -o /usr/local/bin/codex && \
     chmod a+x /usr/local/bin/codex
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,15 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- 主要コードは `src/`、統合テストは `tests/`。運用用は `docker/`、補助ツールは `scripts/`。
+
+- プロジェクトのディレクトリ構成は以下 Cargo Package Layout を採用。
+  - https://doc.rust-lang.org/cargo/guide/project-layout.html
 - リポジトリ規約や CI 設定は `.github/`、開発コンテナは `.devcontainer/` に配置。
 - Rust モジュールは小さく凝集度高く分割し、再利用可能なロジックは `src/lib.rs` へ、実行エントリは `src/main.rs`（該当する場合）。
+- `/README.md` には簡易的なプロジェクトの概要と使い方程度にとどめ、他ドキュメント（ビルド成果物の使い方等）は `/docs` に別途マークダウンファイルを配置して管理。
 
 ## Build, Test, and Development Commands
+
 ```bash
 cargo build --release   # 本番向けビルド
 cargo run               # ローカル実行
@@ -14,47 +18,52 @@ cargo test -- --nocapture  # テスト出力を表示
 cargo fmt --all         # フォーマット
 cargo clippy --all-targets -- -D warnings  # 静的解析（警告をエラー化）
 ```
-- 運用関連は `docker/` のスクリプトを参照。必要に応じ `scripts/` に実行例を追加。
 
 ## Coding Style & Naming Conventions
+
 - フォーマットは `rustfmt` に準拠。PR 前に `cargo fmt --all` を実行。
 - 静的解析は `clippy` を必須とし、警告は解消（`-D warnings`）。
 - 命名: 関数/変数 `snake_case`、型/構造体 `UpperCamelCase`、定数 `UPPER_SNAKE_CASE`。
 - 新規 API は小さくテスト可能に。公開 API はドキュメントコメント（`///`）を付与。
 
-## Dependencies (外部モジュール) 選定基準
-- 原則として依存は極力追加せず、まず自作を検討すること。
+## Dependencies Selection Criteria
+
 - 採用する場合は一般的で広く利用されている外部モジュールを選ぶこと。
 - メンテナンスが継続されていない外部モジュールは選定しないこと。
 
 ## Testing Guidelines
+
 - 標準の Rust テスト（`#[test]`）と統合テスト（`tests/*.rs`）。
 - テスト名は `it_期待する振る舞い` 形式（例: `it_handles_empty_input`）。
 - 重要ロジックには最小限のハッピーパス/エッジケースを用意。ローカルでは `cargo test -- --nocapture` で詳細確認。
 
 ## Commit & Pull Request Guidelines
-- GitHub Flow 準拠。`main` から機能ブランチ作成（例: `feat/parser-refactor`）。小さく頻繁にコミット。
-- コミットメッセージは日本語 + Conventional Commits 形式（タイプ/スコープは英語）、各ファイルの変更内容を列挙。
-```
-feat(parser): 新しいパーサーモジュールを追加
 
-変更したファイル:
-- src/parser/mod.rs: パーサー実装
-- src/lib.rs: 公開モジュールを更新
-```
-- PR には目的、要約、主要変更点、関連 Issue、スクリーンショット/ログ（必要時）を含める。CI 通過と `fmt`/`clippy` 満たすこと。
+- GitHub Flow 準拠。`main` から機能ブランチ作成（例: `feat/parser-refactor`）。小さく頻繁にコミット。
+- コミットメッセージは日本語 + Conventional Commits 形式（タイプ/スコープは英語）、各ファイルの変更内容を列挙。以下例を記載。 
+  ```
+  feat(parser): 新しいパーサーモジュールを追加
+  
+  変更したファイル:
+  - src/parser/mod.rs: パーサー実装
+  - src/lib.rs: 公開モジュールを更新
+  ```
+- PR には目的、要約、主要変更点、関連 Issue、スクリーンショット/ログ（必要時）を含める。CI 通過と `test`/`fmt`/`clippy` 満たすこと。
 
 ## Agent-Specific Notes
+
 - 本ガイドの範囲にある変更は必ず規約に従うこと。無関係な大規模リファクタは避け、影響範囲を最小化。
 - 新しい構造やパターンを導入した場合は、本ファイルや関連ドキュメントを更新すること。
 
 ## Security
+
 - 機密ファイルとして次を読み取ったり変更したりしないこと。
   - `.env` ファイル
   - API キー、トークン、または認証資格情報を含むファイル
 - 機密ファイルの編集が必要な場合は、必ず事前に確認を取ること。
 
 ### Security Guidelines
+
 - 機密ファイルを決してコミットしない
 - 秘密情報には環境変数を使用する
 - ログや出力に認証情報を含めない

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rust 製CLIツールの雛形を含みます。GitHub Flowで運用します。
 ## 使い方
 
 - 初回セットアップ: `cargo build`
-- ローカル実行: `cargo run -- hello --name Rust`
+- ローカル実行: `cargo run -- --name Rust`
 - テスト: `cargo test`
 - フォーマット: `cargo fmt --all`
 - 静的解析: `cargo clippy --all-targets -- -D warnings`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "stable"
-
+targets = ["x86_64-unknown-linux-musl"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use tracing::{info, Level};
 use tracing_subscriber::EnvFilter;
 
@@ -10,18 +10,9 @@ struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand, Debug)]
-enum Commands {
-    /// 挨拶を表示
-    Hello {
-        /// 名前（省略時は "world"）
-        #[arg(short, long)]
-        name: Option<String>,
-    },
+    /// 名前（省略時は "world"）
+    #[arg(short, long)]
+    name: Option<String>,
 }
 
 fn init_tracing(verbosity: u8) {
@@ -46,12 +37,8 @@ fn main() -> Result<()> {
     init_tracing(cli.verbose);
     info!(?cli, "starting CLI");
 
-    match cli.command {
-        Commands::Hello { name } => {
-            let msg = cli_template::greet(name.as_deref());
-            println!("{}", msg);
-        }
-    }
+    let msg = cli_template::greet(cli.name.as_deref());
+    println!("{}", msg);
 
     Ok(())
 }


### PR DESCRIPTION
変更したファイル:
- src/main.rs: コマンド引数のサブコマンドを削除し、名前引数を直接追加
- .devcontainer/Dockerfile: codexのバージョンを0.36.0に更新
- README.md: ローカル実行のコマンドを修正
- rust-toolchain.toml: ターゲットを追加
- .cargo/config.toml: 新規ファイル追加